### PR TITLE
Make background blur keymap agnostic

### DIFF
--- a/vscode-script.js
+++ b/vscode-script.js
@@ -1,6 +1,6 @@
 const TARGET_DIV_CLASS = '.monaco-workbench';
 const COMMAND_CENTER_DIV_CLASS = '.quick-input-widget';
-const BLUR_BACKGROUND_DIV_ID = 'custom-command-center-blur';
+const BLUR_BACKGROUND_DIV_ID = 'command-blur';
 
 document.addEventListener('DOMContentLoaded', () => {
     const checkMonacoWorkbench = setInterval(() => {


### PR DESCRIPTION
The previous implementation of the background blur depended on the user having the default VSCode keymaps in order to trigger the background blur. This implementation fixes that by using observers to detect when the command center has been triggered and set the background accordingly.