### PR TITLE
fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
     // "file:///Users/your-user-name/custom-vscode.css",
     // "file:///Users/your-user-name/custom-vscode-script.js"
 
-    // For Windows (use double backslash `\\` for Windows paths)
-    // "file:///C:\\path-of-custom-css\\custom-vscode.css",
-    // "file:///C:\\path-of-custom-css\\custom-vscode-script.js"
+    // For Windows
+    // "file:///C:/path-of-custom-css/custom-vscode.css",
+    // "file:///C:/path-of-custom-css/custom-vscode-script.js"
 ],
 ```
 4. You might need to take ownership of the CSS/JS files you made or run VS Code with admin privileges on certain operating system:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 "vscode_custom_css.imports": [
     // Absolute file paths for your css/js files
     // For Mac or Linux
-    // "file:///Users/your-user-name/custom-vscode.css"
+    // "file:///Users/your-user-name/custom-vscode.css",
     // "file:///Users/your-user-name/custom-vscode-script.js"
 
-    // For Windows
-    // "file:///C:\path-of-custom-css\custom-vscode.css"
-    // "file:///C:\path-of-custom-css\custom-vscode-script.js"
+    // For Windows (use double backslash `\\` for Windows paths)
+    // "file:///C:\\path-of-custom-css\\custom-vscode.css",
+    // "file:///C:\\path-of-custom-css\\custom-vscode-script.js"
 ],
 ```
 4. You might need to take ownership of the CSS/JS files you made or run VS Code with admin privileges on certain operating system:


### PR DESCRIPTION
fix missing commas and instructions for windows

When a user uncomments these lines `Ctrl+/` theres missing commas, which for a non-technical user might present an issue
Also, for people who are unaware, the windows path names have to be in double backslash to properly be escaped!