### PR TITLE
fix: 🐛 centre action next to command input box

### DIFF
--- a/custom-vscode.css
+++ b/custom-vscode.css
@@ -240,7 +240,10 @@
 
 /* Actions after command palette text input */
 .quick-input-inline-action-bar .actions-container .action-item{
-	padding: 17px 0 !important;
+	margin-bottom: 16px !important; /* Same margin-bottom as .monaco-inputbox */
+}
+.quick-input-header{
+	align-items: center;
 }
 
 /* Command palette's input box placeholder. */

--- a/custom-vscode.css
+++ b/custom-vscode.css
@@ -238,6 +238,11 @@
     backdrop-filter: blur(8px);
 }
 
+/* Actions after command palette text input */
+.quick-input-inline-action-bar .actions-container .action-item{
+	padding: 17px 0 !important;
+}
+
 /* Command palette's input box placeholder. */
 .monaco-inputbox input::placeholder {
     color: rgba(255, 255, 255, .3) !important;


### PR DESCRIPTION
There's conditional action next command line input box, which was not aligned.

For example, if you "%" to search text from command palette you get action as "Open in search view" which was not aligned.