### PR TITLE
Enhance blur and increase logi width

### DIFF
--- a/vscode-script.js
+++ b/vscode-script.js
@@ -1,95 +1,103 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const checkElement = setInterval(() => {
-        const commandDialog = document.querySelector(".quick-input-widget");
-        if (commandDialog) {
-          // Apply the blur effect immediately if the command dialog is visible
-          if (commandDialog.style.display !== "none") {
-            runMyScript();
-          }
-            // Create an DOM observer to 'listen' for changes in element's attribute.
-            const observer = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
-                        if (commandDialog.style.display === 'none') {
-                            handleEscape();
-                        } else {
-                            // If the .quick-input-widget element (command palette) is in the DOM
-                            // but no inline style display: none, show the backdrop blur.
-                            runMyScript();
+    // ====================================================================================
+    // Enhanced Command Palette Blur Effect
+    //
+    // This script adds a blur effect to the background when the VS Code command
+    // palette is opened. It's designed to be more performant and resilient
+    // to VS Code updates.
+    // ====================================================================================
+
+    const body = document.body;
+    let commandBlurElement = null;
+
+    /**
+     * Applies the blur effect and hides sticky elements.
+     */
+    function showBlurEffect() {
+        if (!commandBlurElement) {
+            commandBlurElement = document.createElement("div");
+            commandBlurElement.id = 'command-blur';
+            commandBlurElement.addEventListener('click', hideBlurEffect);
+            document.querySelector(".monaco-workbench").appendChild(commandBlurElement);
+        }
+        commandBlurElement.style.display = 'block';
+
+        // Hide sticky widgets for a cleaner look
+        document.querySelectorAll(".sticky-widget, .monaco-tree-sticky-container").forEach(widget => {
+            widget.style.opacity = 0;
+        });
+    }
+
+    /**
+     * Removes the blur effect and restores sticky elements.
+     */
+    function hideBlurEffect() {
+        if (commandBlurElement) {
+            commandBlurElement.style.display = 'none';
+        }
+
+        // Restore sticky widgets
+        document.querySelectorAll(".sticky-widget, .monaco-tree-sticky-container").forEach(widget => {
+            widget.style.opacity = 1;
+        });
+    }
+
+    /**
+     * Handles all keydown events for the command palette.
+     * @param {KeyboardEvent} event
+     */
+    function handleKeyDown(event) {
+        const isCommandPaletteKey = (event.metaKey || event.ctrlKey) && event.key === 'p';
+        const isEscapeKey = event.key === 'Escape' || event.key === 'Esc';
+
+        if (isCommandPaletteKey) {
+            event.preventDefault();
+            // The observer will handle showing the blur effect.
+        } else if (isEscapeKey) {
+            // The observer will handle hiding the blur effect.
+        }
+    }
+
+    // Use a MutationObserver to efficiently detect when the command palette is shown or hidden.
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            if (mutation.type === 'childList' && mutation.addedNodes.length) {
+                for (const node of mutation.addedNodes) {
+                    if (node.classList && node.classList.contains('quick-input-widget')) {
+                        // Command palette was added to the DOM, start observing its style for changes.
+                        observeStyleChanges(node);
+                        // If it's already visible, apply the effect.
+                        if (node.style.display !== 'none') {
+                            showBlurEffect();
                         }
                     }
-                });
-            });
-
-            observer.observe(commandDialog, { attributes: true });
-
-            // Clear the interval once the observer is set
-            clearInterval(checkElement);
-        } else {
-            console.log("Command dialog not found yet. Retrying...");
-        }
-    }, 500); // Check every 500ms
-
-    // Execute when command palette was launched.
-    document.addEventListener('keydown', function(event) {
-        if ((event.metaKey || event.ctrlKey) && event.key === 'p') {
-            event.preventDefault();
-            runMyScript();
-        } else if (event.key === 'Escape' || event.key === 'Esc') {
-            event.preventDefault();
-            handleEscape();
+                }
+            }
         }
     });
 
-    // Ensure the escape key event listener is at the document level
-    document.addEventListener('keydown', function(event) {
-        if (event.key === 'Escape' || event.key === 'Esc') {
-            handleEscape();
-        }
-    }, true);
-
-    function runMyScript() {
-        const targetDiv = document.querySelector(".monaco-workbench");
-
-        // Remove existing element if it already exists
-        const existingElement = document.getElementById("command-blur");
-        existingElement && existingElement.remove();
-
-        // Create and configure the new element
-        const newElement = document.createElement("div");
-        newElement.setAttribute('id', 'command-blur');
-
-        newElement.addEventListener('click', function() {
-            newElement.remove();
+    /**
+     * Observes the style attribute of the command palette to detect visibility changes.
+     * @param {HTMLElement} commandPalette
+     */
+    function observeStyleChanges(commandPalette) {
+        const styleObserver = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.attributeName === 'style') {
+                    if (commandPalette.style.display === 'none') {
+                        hideBlurEffect();
+                    } else {
+                        showBlurEffect();
+                    }
+                }
+            });
         });
-
-        // Append the new element as a child of the targetDiv
-        targetDiv.appendChild(newElement);
-
-        // Hide the sticky widget
-        const widgets = document.querySelectorAll(".sticky-widget");
-        widgets.forEach((widget) => {
-            widget.style.opacity = 0;
-        });
-
-        // Hide the tree sticky widget
-        const treeWidget = document.querySelector(".monaco-tree-sticky-container");
-        treeWidget && (treeWidget.style.opacity = 0);
+        styleObserver.observe(commandPalette, { attributes: true, attributeFilter: ['style'] });
     }
 
-    // Remove the backdrop blur from the DOM when esc key is pressed.
-    function handleEscape() {
-        const element = document.getElementById("command-blur");
-        element && element.click();
+    // Start observing the body for the command palette to be added.
+    observer.observe(body, { childList: true, subtree: true });
 
-        // Show the sticky widget
-        const widgets = document.querySelectorAll(".sticky-widget");
-        widgets.forEach((widget) => {
-            widget.style.opacity = 1;
-        });
-
-        // Show the tree sticky widget
-        const treeWidget = document.querySelector(".monaco-tree-sticky-container");
-        treeWidget && (treeWidget.style.opacity = 1);
-    }
+    // Add a single, more efficient event listener for keyboard shortcuts.
+    document.addEventListener('keydown', handleKeyDown, true);
 });


### PR DESCRIPTION
This pull request updates the custom blur effect for the VS Code command palette to be more efficient, robust, and compatible with future updates. The changes improve both the JavaScript logic for applying/removing the blur effect and the CSS for the blur overlay.

Enhancements to the command palette blur effect:

* Refactored `vscode-script.js` to use MutationObservers for detecting when the command palette is shown or hidden, improving performance and reliability over the previous polling approach. The script now efficiently applies and removes the blur effect and manages sticky widget visibility.
* Added comments and modularized the JavaScript for clarity and maintainability, with separated functions for showing/hiding the blur and handling keyboard events.

Visual improvements:

* Increased the blur overlay width in `custom-vscode.css` from 60% to 90% for better coverage when the command palette is open.

⚠ Width can be subjective maybe we can do 75-80 if you want